### PR TITLE
Updating for DSM 7.x and Target Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,8 @@ Author Information
 ------------------
 
 https://github.com/JohnVillalovos
+
+Contributors
+------------
+
+https://github.com/pezhore


### PR DESCRIPTION
This was a godsend for automating certificate updates with my homelab, but I noticed the python code didn't work with DSM 7.x.

This Pull Request does the following:

1. Updates the helper script `print-certs.yml` to include filtering options for specific CNs, and fixes a bug with DSM 7.x that prevented a valid split on the `host_name` variable.
2. The helper script gains the ability to filter out the `_archive` folder if desired by omitting the `-a` or `--allcerts` flags.
3. The helper script gains the ability to filter on a given target CN. This was useful as I had a few different certs from Synology and for specific services that I wanted to leave untouched. When omitting the `--target <TARGET>` flag.
4. Lastly, the helper script gains a more robust help output in case the python code is run outside of the ansible playbook.

I also added my Github link to a new Contributors section on the main README.md, but that can come off if desired.